### PR TITLE
chore: include attestation docs & example

### DIFF
--- a/contracts/attestation/TrufAttestationConsumer.sol
+++ b/contracts/attestation/TrufAttestationConsumer.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.27;
+
+import {TrufAttestation} from "./TrufAttestation.sol";
+
+/// @title TrufAttestationConsumer
+/// @notice Example contract that verifies TrufNetwork attestations and stores the latest datapoint.
+contract TrufAttestationConsumer {
+    using TrufAttestation for bytes;
+    using TrufAttestation for TrufAttestation.Attestation;
+
+    error AttestationConsumerInvalidSigner(address expected);
+    error AttestationConsumerEmptyResult();
+    error AttestationConsumerOnlyOwner();
+    error AttestationConsumerLeaderNotSet();
+
+    address public owner;
+    address public leader;
+    address public lastValidator;
+    uint64 public lastBlockHeight;
+    bytes32 public lastStreamId;
+    uint8 public lastActionId;
+    uint256 public lastTimestamp;
+    int256 public lastValue;
+
+    event AttestationConsumed(
+        address indexed validator,
+        uint64 blockHeight,
+        bytes32 indexed streamId,
+        uint8 actionId,
+        uint256 timestamp,
+        int256 value
+    );
+
+    event LeaderUpdated(address indexed leader);
+
+    constructor() {
+        owner = msg.sender;
+    }
+
+    /// @notice Set the expected validator address. Example only; wire into governance in production.
+    function setLeader(address newLeader) external {
+        if (msg.sender != owner) revert AttestationConsumerOnlyOwner();
+        leader = newLeader;
+        emit LeaderUpdated(newLeader);
+    }
+
+    /// @notice Verify an attestation payload against the stored leader and persist the latest datapoint.
+    /// @param payload Signed attestation bytes produced by the TrufNetwork node.
+    function consume(bytes calldata payload) external {
+        address expectedValidator = leader;
+        if (expectedValidator == address(0)) revert AttestationConsumerLeaderNotSet();
+
+        TrufAttestation.Attestation memory att = payload.parse();
+
+        if (!att.verify(expectedValidator)) {
+            revert AttestationConsumerInvalidSigner(expectedValidator);
+        }
+
+        TrufAttestation.DataPoint[] memory points = TrufAttestation.decodeDataPoints(att);
+        if (points.length == 0) revert AttestationConsumerEmptyResult();
+
+        TrufAttestation.DataPoint memory latest = points[points.length - 1];
+
+        lastValidator = expectedValidator;
+        lastBlockHeight = att.blockHeight;
+        lastStreamId = att.streamId;
+        lastActionId = att.actionId;
+        lastTimestamp = latest.timestamp;
+        lastValue = latest.value;
+
+        emit AttestationConsumed(expectedValidator, att.blockHeight, att.streamId, att.actionId, latest.timestamp, latest.value);
+    }
+}

--- a/docs/AttestationLibrary.md
+++ b/docs/AttestationLibrary.md
@@ -60,3 +60,8 @@ They mirror the canonical encoder maintained in the TrufNetwork node repo (`gith
 - Track digests/block heights to enforce replay and freshness policies.
 - Aggregate multiple attestations (median/quorum) in downstream contracts if required.
 - Surface verification failures in logs/metrics instead of swallowing them silently.
+
+## Example Contract
+- A minimal, non-production example lives at `contracts/attestation/TrufAttestationConsumer.sol`. It keeps a single owner-set leader and shows how to persist the latest datapoint.
+- The accompanying test suite (`test/attestation/TrufAttestationConsumer.test.ts`) demonstrates end-to-end verification using the golden fixture.
+- Replace the leader management with your own governance/allowlist logic before shipping to mainnet.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "description": "Truf Network EVM contracts",
   "scripts": {
-    "run:direct": "deno run --no-prompt --allow-net deno-src/source.ts"
+    "run:direct": "deno run --no-prompt --allow-net deno-src/source.ts",
+    "test": "hardhat test test/attestation/TrufAttestation.test.ts test/attestation/TrufAttestationConsumer.test.ts"
   },
   "dependencies": {
     "@chainlink/functions-toolkit": "0.3.2",

--- a/test/attestation/TrufAttestationConsumer.test.ts
+++ b/test/attestation/TrufAttestationConsumer.test.ts
@@ -1,0 +1,101 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { buildCanonical, buildPayload, CanonicalFields } from "../helpers/attestation";
+import { GOLDEN_PAYLOAD, goldenFixture } from "./golden";
+
+describe("TrufAttestationConsumer", function () {
+  async function deployConsumer() {
+    const factory = await ethers.getContractFactory("TrufAttestationConsumer");
+    return factory.deploy();
+  }
+
+  it("consumes a valid attestation and stores the latest datapoint", async function () {
+    const consumer = await deployConsumer();
+    const validator = ethers.getAddress(goldenFixture.data_provider);
+    await consumer.setLeader(validator);
+
+    const lastTimestamp = BigInt(goldenFixture.result.timestamps[goldenFixture.result.timestamps.length - 1]);
+    const lastValue = ethers.parseUnits(goldenFixture.result.values[goldenFixture.result.values.length - 1], 18);
+    const expectedStreamId = ethers.hexlify(ethers.toUtf8Bytes(goldenFixture.stream_id));
+
+    await expect(consumer.consume(GOLDEN_PAYLOAD))
+      .to.emit(consumer, "AttestationConsumed")
+      .withArgs(
+        validator,
+        BigInt(goldenFixture.block_height),
+        expectedStreamId,
+        goldenFixture.action_id,
+        lastTimestamp,
+        lastValue
+      );
+
+    expect(await consumer.lastValidator()).to.equal(validator);
+    expect(await consumer.lastBlockHeight()).to.equal(BigInt(goldenFixture.block_height));
+    expect(await consumer.lastStreamId()).to.equal(expectedStreamId);
+    expect(await consumer.lastActionId()).to.equal(goldenFixture.action_id);
+    expect(await consumer.lastTimestamp()).to.equal(lastTimestamp);
+    expect(await consumer.lastValue()).to.equal(lastValue);
+  });
+
+  it("reverts when validator is not trusted", async function () {
+    const consumer = await deployConsumer();
+    const validator = ethers.getAddress(goldenFixture.data_provider);
+    await consumer.setLeader(validator);
+    const tamperedPayload = (() => {
+      const canonical = Buffer.from(goldenFixture.canonical_hex, "hex");
+      canonical[canonical.length - 1] ^= 0xff;
+      const signature = Buffer.from(goldenFixture.signature_hex, "hex");
+      return `0x${Buffer.concat([canonical, signature]).toString("hex")}`;
+    })();
+    await expect(consumer.consume(tamperedPayload)).to.be.revertedWithCustomError(
+      consumer,
+      "AttestationConsumerInvalidSigner"
+    );
+  });
+
+  it("reverts when attestation result is empty", async function () {
+    const consumer = await deployConsumer();
+    const signer = ethers.Wallet.createRandom();
+    await consumer.setLeader(signer.address);
+
+    const fields: CanonicalFields = {
+      version: 1,
+      algorithm: 0,
+      blockHeight: 777n,
+      dataProvider: signer.address,
+      streamId: ethers.hexlify(ethers.randomBytes(32)),
+      actionId: 1,
+      args: ethers.getBytes("0x"),
+      result: ethers.getBytes(
+        ethers.AbiCoder.defaultAbiCoder().encode(["uint256[]", "int256[]"], [[], []])
+      ),
+    };
+
+    const canonical = buildCanonical(fields);
+    const digest = ethers.sha256(canonical);
+    const signature = ethers.Signature.from(signer.signingKey.sign(ethers.getBytes(digest))).serialized;
+    const payload = buildPayload(fields, ethers.getBytes(signature));
+
+    await expect(consumer.consume(payload)).to.be.revertedWithCustomError(
+      consumer,
+      "AttestationConsumerEmptyResult"
+    );
+  });
+
+  it("only owner can set leader", async function () {
+    const consumer = await deployConsumer();
+    const [, other] = await ethers.getSigners();
+    await expect(consumer.connect(other).setLeader(other.address)).to.be.revertedWithCustomError(
+      consumer,
+      "AttestationConsumerOnlyOwner"
+    );
+  });
+
+  it("reverts when leader is not configured", async function () {
+    const consumer = await deployConsumer();
+    await expect(consumer.consume(GOLDEN_PAYLOAD)).to.be.revertedWithCustomError(
+      consumer,
+      "AttestationConsumerLeaderNotSet"
+    );
+  });
+});

--- a/test/attestation/golden.ts
+++ b/test/attestation/golden.ts
@@ -1,0 +1,31 @@
+import fs from "fs";
+import path from "path";
+
+const goldenPath = path.resolve(__dirname, "./fixtures/attestation_golden.json");
+
+export type GoldenFixture = {
+  canonical_hex: string;
+  signature_hex: string;
+  payload_hex: string;
+  data_provider: string;
+  stream_id: string;
+  block_height: number;
+  action_id: number;
+  args: {
+    data_provider: string;
+    stream_id: string;
+    start_time: number;
+    end_time: number;
+    pending_filter: null | string;
+    use_cache: boolean;
+  };
+  result: {
+    timestamps: number[];
+    values: string[];
+  };
+};
+
+export const goldenFixture = JSON.parse(fs.readFileSync(goldenPath, "utf8")) as GoldenFixture;
+export const GOLDEN_CANONICAL = `0x${goldenFixture.canonical_hex}`;
+export const GOLDEN_SIGNATURE = `0x${goldenFixture.signature_hex}`;
+export const GOLDEN_PAYLOAD = `0x${goldenFixture.payload_hex}`;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

- Introduced TrufAttestationConsumer.sol contract for verifying and storing TrufNetwork attestations.
- Added comprehensive tests in TrufAttestationConsumer.test.ts to validate attestation consumption and error handling.
- Updated package.json to include a test script for the new consumer contract.
- Enhanced documentation to include details about the new contract and its usage.

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

- fix #7 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TrufAttestationConsumer contract for verifying attestations from designated leaders and storing the latest datapoint with owner-based access control.

* **Documentation**
  * Updated Attestation Library documentation with example contract implementation and best practices for leader management before mainnet deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->